### PR TITLE
fix: make real IP forwarding optional and modernize build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.0.9
+
+- Make real client IP forwarding optional through `forward_real_ip`.
+  The default is disabled so the add-on works without extra Home
+  Assistant `trusted_proxies` configuration.
+- Keep the recommended trusted proxy setup documented for users who
+  want Home Assistant to see the real weather station IP.
+- Restrict `/status/internal` to loopback and the Supervisor add-on
+  network instead of exposing it to the whole private LAN.
+- Use the current Home Assistant internal hostname (`homeassistant`) as
+  the nginx upstream.
+- Stop relying on legacy `build.yaml` / `BUILD_FROM` for local
+  Supervisor builds.
+
 ## 0.0.8 — Sincere apology + fix for the 0.0.7 breakage
 
 **Please update immediately if you are on 0.0.7.**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG BUILD_FROM
-FROM $BUILD_FROM
+ARG BUILD_ARCH=amd64
+FROM ghcr.io/home-assistant/${BUILD_ARCH}-base:3.21
 
 # Copy data for add-on
 COPY run.sh /
@@ -9,11 +9,10 @@ RUN chmod a+x /run.sh
 
 RUN \
   apk add --no-cache \
-  nginx
-
-RUN apk add --no-cache openssl
-
-RUN apk add --no-cache curl jq
+    curl \
+    jq \
+    nginx \
+    openssl
 
 
 CMD [ "/run.sh" ]

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Before starting the add-on, configure these fields:
 - `HA port`: Plain HTTP port where Home Assistant listens internally, usually `8123`.
 - `cert valid for`: Number of days the generated self-signed certificate stays valid.
 - `auto recreate certificate`: Recreates the certificate when it no longer matches the configured host name or IP address, or when it is near expiration. Restart the add-on after changing these settings.
+- `forward real client IP`: Sends the weather station IP to Home Assistant using reverse proxy headers. Leave disabled unless Home Assistant is configured with `trusted_proxies`.
 
 ## Usage
 
@@ -63,15 +64,19 @@ Before starting the add-on, configure these fields:
 
 Some stations are configured through the WSLink application but still send data using the older PWS protocol over SSL. If data does not appear in Home Assistant, check whether the target integration expects WSLink or PWS and adjust the integration settings accordingly.
 
-### Required Home Assistant configuration (reverse proxy)
+### Recommended Home Assistant configuration (trusted proxy)
 
-Starting with **0.0.8**, the add-on forwards the real client IP to Home Assistant using the `X-Forwarded-For` header. Home Assistant will reject those requests — and log
+Home Assistant can either see requests as coming from the add-on container, or it can see the real IP address of the weather station.
+
+By default, the add-on does not forward the real client IP. This works without extra Home Assistant configuration and is the most compatible mode.
+
+The recommended setup is to enable `forward real client IP` in the add-on and allow Home Assistant to trust this add-on as a reverse proxy. With this enabled, Home Assistant receives the real station IP through the `X-Forwarded-For` header. This is better for diagnostics, logging, and IP bans: if credentials are wrong, Home Assistant can identify the station itself instead of treating the add-on container as the client.
+
+If Home Assistant receives `X-Forwarded-For` from the add-on without being configured to trust it, it will reject the request and log:
 
 > A request from a reverse proxy was received from 172.30.33.x, but your HTTP integration is not set-up for reverse proxies
 
-— unless it is explicitly told to trust the add-on as a proxy.
-
-Add the following to your `configuration.yaml` and restart Home Assistant:
+To use real client IP forwarding, first add the following to your Home Assistant `configuration.yaml` and restart Home Assistant:
 
 ```yaml
 http:
@@ -82,9 +87,10 @@ http:
 
 Notes:
 
+- Enable `forward real client IP` in the add-on only after Home Assistant has been restarted with the trusted proxy configuration above.
 - `172.30.0.0/16` covers the whole Supervisor internal network, which is where all add-ons live. If you prefer a tighter range, the WSLink add-on's container IP typically falls in `172.30.32.0/23`, but the `/16` above is the safe, forward-compatible choice.
 - If you already have an `http:` block in `configuration.yaml`, merge the two keys into it — do not add a second `http:` section.
-- Without this configuration, uploads through the add-on will fail authentication and — because Home Assistant treats repeated 401s as failed logins — the add-on's internal IP can end up on the HA IP-ban list. If that happens, remove the offending entry from `/config/ip_bans.yaml` and restart Home Assistant.
+- If uploads fail repeatedly and Home Assistant bans an IP, remove the offending entry from `/config/ip_bans.yaml` and restart Home Assistant.
 
 ## Status endpoints
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,0 @@
-build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.21
-  amd64: ghcr.io/home-assistant/amd64-base:3.21
-  armhf: ghcr.io/home-assistant/armhf-base:3.21
-  armv7: ghcr.io/home-assistant/armv7-base:3.21
-  i386: ghcr.io/home-assistant/i386-base:3.21

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "WSLink proxy add-on"
 description: "Create a proxy SSL for WSLink support"
-version: "0.0.8"
+version: "0.0.9"
 slug: "wslink_proxy"
 url: "https://github.com/schizza/wslink-addon"
 init: false
@@ -20,10 +20,12 @@ options:
   ha_port: 8123
   cert_valid_for: 65535
   auto_recreate_cert: false
+  forward_real_ip: false
 
 schema:
   host_name: str
   host_ip: str
-  ha_port: int
+  ha_port: port
   cert_valid_for: int
   auto_recreate_cert: bool
+  forward_real_ip: bool

--- a/rootfs/etc/nginx/nginx.conf.gtpl
+++ b/rootfs/etc/nginx/nginx.conf.gtpl
@@ -9,7 +9,7 @@ events {
 http {
     map_hash_bucket_size 128;
 
-    # Docker embedded DNS — lets us re-resolve HA's internal IP without a restart
+    # Docker embedded DNS lets us re-resolve HA's internal IP without a restart.
     resolver 127.0.0.11 ipv6=off valid=10s;
     resolver_timeout 5s;
 
@@ -45,31 +45,31 @@ http {
         }
 
         location = /data/upload.php {
-            set $ha_upstream homeassistant.local.hass.io;
+            set $ha_upstream homeassistant;
             proxy_connect_timeout 3s;
             proxy_send_timeout    10s;
             proxy_read_timeout    10s;
             proxy_next_upstream   error timeout;
-            proxy_set_header      X-Forwarded-For $remote_addr;
+            include /etc/nginx/real_ip_headers.conf;
             # $is_args$args is required: when proxy_pass contains a variable,
             # nginx does NOT forward the original query string automatically.
             proxy_pass http://$ha_upstream:{{ ha_port }}/data/upload.php$is_args$args;
         }
 
         location = /weatherstation/updateweatherstation.php {
-            set $ha_upstream homeassistant.local.hass.io;
+            set $ha_upstream homeassistant;
             proxy_connect_timeout 3s;
             proxy_send_timeout    10s;
             proxy_read_timeout    10s;
             proxy_next_upstream   error timeout;
-            proxy_set_header      X-Forwarded-For $remote_addr;
+            include /etc/nginx/real_ip_headers.conf;
             # $is_args$args is required: when proxy_pass contains a variable,
             # nginx does NOT forward the original query string automatically.
             proxy_pass http://$ha_upstream:{{ ha_port }}/weatherstation/updateweatherstation.php$is_args$args;
         }
 
         location = /healthz {
-            add_header Content-Type text/plain;
+            default_type text/plain;
             return 200 "ok\n";
         }
 
@@ -82,9 +82,6 @@ http {
         location = /status/internal {
           allow 127.0.0.1;
           allow 172.30.0.0/16;
-          allow 172.16.0.0/12;
-          allow 192.168.0.0/16;
-          allow 10.0.0.0/8;
           deny all;
 
           default_type application/json;

--- a/run.sh
+++ b/run.sh
@@ -9,6 +9,7 @@ HOST_IP="$(bashio::config 'host_ip')"
 CERT_VALID_FOR="$(bashio::config 'cert_valid_for')"
 AUTO_RECREATE_CERT="$(bashio::config 'auto_recreate_cert')"
 HA_PORT="$(bashio::config 'ha_port')"
+FORWARD_REAL_IP="$(bashio::config 'forward_real_ip')"
 
 RED_COLOR='\033[0;31m'
 GREEN_COLOR='\033[0;32m'
@@ -100,10 +101,24 @@ function get_external_port() {
     jq -r '.data.network["443/tcp"] // empty')"
 
   if [ -z "$port" ] || [ "$port" = "null" ]; then
+    warn "Could not read effective external port from Supervisor API. Falling back to 443." >&2
     port="443"
   fi
 
   echo "$port"
+}
+
+function create_real_ip_headers_conf() {
+  if [ "$FORWARD_REAL_IP" == "true" ]; then
+    info "Forwarding real client IP to Home Assistant."
+    cat >/etc/nginx/real_ip_headers.conf <<EOF
+proxy_set_header X-Forwarded-For \$remote_addr;
+proxy_set_header X-Real-IP \$remote_addr;
+EOF
+  else
+    info "Real client IP forwarding is disabled."
+    : >/etc/nginx/real_ip_headers.conf
+  fi
 }
 
 check "openssl" true
@@ -156,6 +171,7 @@ fi
 
 # Create nginx.conf
 info "Creating nginx configuration file..."
+create_real_ip_headers_conf
 sed -e "s/{{ ha_port }}/${HA_PORT}/g" \
   /etc/nginx/nginx.conf.gtpl >/etc/nginx/nginx.conf
 

--- a/translations/cs.yaml
+++ b/translations/cs.yaml
@@ -14,3 +14,6 @@ configuration:
   auto_recreate_cert:
     name: Automaticky obnovit certifikát
     description: Obnoví certifikát, pokud přestane odpovídat konfiguraci nebo se blíží expirace.
+  forward_real_ip:
+    name: Předávat skutečnou IP klienta
+    description: Pošle IP adresu meteostanice do Home Assistantu pomocí reverse proxy hlaviček. Vyžaduje trusted proxies v Home Assistantu. Před zapnutím se podívejte do README.

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -15,3 +15,6 @@ configuration:
   auto_recreate_cert:
     name: Auto recreate certificate
     description: Recreate the certificate when it no longer matches the configuration or is near expiration.
+  forward_real_ip:
+    name: Forward real client IP
+    description: Send the weather station IP to Home Assistant using reverse proxy headers. Requires trusted proxies in Home Assistant. See README before enabling.


### PR DESCRIPTION
- Stop relying on legacy build.yaml / BUILD_FROM behavior
- Add forward_real_ip option with translations and README guidance
- Keep default mode compatible without Home Assistant trusted_proxies
- Restrict internal status endpoint to loopback and Supervisor network
- Use current Home Assistant internal hostname for nginx upstream